### PR TITLE
Fix list repositories returning images only

### DIFF
--- a/src/repos.ts
+++ b/src/repos.ts
@@ -261,14 +261,16 @@ export class Repos extends Asset {
                         media_types: z
                             .string()
                             .optional()
+                            .default('')
                             .describe(
-                                'Comma-delimited list of media types. Only repositories containing one or more artifacts with one of these media types will be returned. null should be added to the list to get repositories with image artifacts to handle legacy repositories.'
+                                'Comma-delimited list of media types. Only repositories containing one or more artifacts with one of these media types will be returned. Default is empty to get all repositories.'
                             ),
                         content_types: z
                             .string()
                             .optional()
+                            .default('')
                             .describe(
-                                'Comma-delimited list of content types. Only repositories containing one or more artifacts with one of these content types will be returned.'
+                                'Comma-delimited list of content types. Only repositories containing one or more artifacts with one of these content types will be returned. Default is empty to get all repositories.'
                             ),
                     },
                     outputSchema: repositoryPaginatedResponseSchema.shape,

--- a/tools.json
+++ b/tools.json
@@ -32,11 +32,13 @@
                     },
                     "media_types": {
                         "type": "string",
-                        "description": "Comma-delimited list of media types. Only repositories containing one or more artifacts with one of these media types will be returned. null should be added to the list to get repositories with image artifacts to handle legacy repositories."
+                        "default": "",
+                        "description": "Comma-delimited list of media types. Only repositories containing one or more artifacts with one of these media types will be returned. Default is empty to get all repositories."
                     },
                     "content_types": {
                         "type": "string",
-                        "description": "Comma-delimited list of content types. Only repositories containing one or more artifacts with one of these content types will be returned."
+                        "default": "",
+                        "description": "Comma-delimited list of content types. Only repositories containing one or more artifacts with one of these content types will be returned. Default is empty to get all repositories."
                     }
                 },
                 "required": ["namespace"],


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
The `listRepositoriesByNamespace` was only returning repos with image as content.
## Tool Details
<!-- If modifying an existing tool, provide details -->
- Tool: <!-- e.g., filesystem, github -->
- Changes to: <!-- e.g., input schema, output schema, description, logic -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [ ] I have updated the server README accordingly
- [ ] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->