### PR TITLE
Fix multiple repository tools

### DIFF
--- a/src/repos.ts
+++ b/src/repos.ts
@@ -613,7 +613,7 @@ export class Repos extends Asset {
         full_description?: string;
         status?: string | null;
     }): Promise<CallToolResult> {
-        let extraContent: { type: 'text'; text: string }[] = [];
+        const extraContent: { type: 'text'; text: string }[] = [];
         if (!namespace || !repository) {
             throw new Error('Namespace and repository name are required');
         }
@@ -621,7 +621,7 @@ export class Repos extends Asset {
             `Updating repository ${repository} in ${namespace} with description: ${description}, full_description: ${full_description}, status: ${status}`
         );
         const url = `${this.config.host}/namespaces/${namespace}/repositories/${repository}`;
-        let body: { description?: string; full_description?: string; status?: number } = {};
+        const body: { description?: string; full_description?: string; status?: number } = {};
         if (description && description !== '') {
             body.description = description;
         }

--- a/tools.json
+++ b/tools.json
@@ -618,7 +618,7 @@
         },
         {
             "name": "createRepository",
-            "description": "Create a new repository in the given namespace. User must pass the repository name and if the repository has to be public or private. Can optionally pass a description.",
+            "description": "Create a new repository in the given namespace. You MUST ask the user for the repository name and if the repository has to be public or private. Can optionally pass a description.\nIMPORTANT: Before calling this tool, you must ensure you have:\n - The repository name (name).",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -628,7 +628,8 @@
                     },
                     "name": {
                         "type": "string",
-                        "description": "The name of the repository. Must contain a combination of alphanumeric characters and may contain the special characters ., _, or -. Letters must be lowercase. Required."
+                        "default": "",
+                        "description": "The name of the repository (required). Must contain a combination of alphanumeric characters and may contain the special characters ., _, or -. Letters must be lowercase."
                     },
                     "description": {
                         "type": "string",
@@ -648,7 +649,7 @@
                         "description": "The registry to create the repository in"
                     }
                 },
-                "required": ["namespace", "name"],
+                "required": ["namespace"],
                 "additionalProperties": false,
                 "$schema": "http://json-schema.org/draft-07/schema#"
             },
@@ -1154,10 +1155,12 @@
                 "type": "object",
                 "properties": {
                     "namespace": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "The namespace of the repository (required). If not provided the `library` namespace will be used for official images."
                     },
                     "repository": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "The repository name (required)"
                     }
                 },
                 "required": ["namespace", "repository"],
@@ -1661,25 +1664,45 @@
         },
         {
             "name": "updateRepositoryInfo",
-            "description": "Update the details of a repository in the given namespace.",
+            "description": "Update the details of a repository in the given namespace. Description, overview and status are the only fields that can be updated. While description and overview changes are fine, a status change is a dangerous operation so the user must explicitly ask for it.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "namespace": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "The namespace of the repository (required)"
                     },
                     "repository": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "The repository name (required)"
                     },
                     "description": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "The description of the repository. If user asks for updating the description of the repository, this is the field that should be updated."
                     },
                     "full_description": {
                         "type": "string",
-                        "maxLength": 25000
+                        "maxLength": 25000,
+                        "description": "The full description (overview)of the repository. If user asks for updating the full description or the overview of the repository, this is the field that should be updated. "
                     },
                     "status": {
-                        "type": "number"
+                        "anyOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "not": {}
+                                    },
+                                    {
+                                        "type": "string",
+                                        "enum": ["active", "inactive"]
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "The status of the repository. If user asks for updating the status of the repository, this is the field that should be updated. This is a dangerous operation and should be done with caution so user must be prompted to confirm the operation. Valid status are `active` (1) and `inactive` (0). Normally do not update the status if it is not strictly required by the user. It is not possible to change an `inactive` repository to `active` if it has no images."
                     }
                 },
                 "required": ["namespace", "repository"],


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
- Improve update repository tool by reducing the noise of LLM trying to update the status: 
   - status can be updated only if user explicitly asks for a status change.
   - when user asks for description/overview update LLM does not set status=1 anymore (this caused the API call to fail for inactive repositories that could not be changed to active)
- Improve get repository to handle the case of official images (with no namespace)
- Improve createRepository to force user (as much as possible) providing the repository name

## Update Repository (fail to change status)
```
>>> update description to "a new description" for pippo repository in lucadruda475 namespace. Also update status to be active                                                                                                    
                                                                                                                                                                                                                                 
    • Calling updateRepositoryInfo...                                                                                                                                                                                            
                                                                                                                                                                                                                                 
  The repository "pippo" in the "lucadruda475" namespace is currently inactive and has no images, so it cannot be changed to active. I have updated the description to "a new description" as requested. If you want, I can      
  proceed with updating only the description. Would you like me to do that?                                                                                                                                                      
                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                 

>>> yes please                                                                                                                                                                                                                   
                                                                                                                                                                                                                                 
    • Calling updateRepositoryInfo...                                                                                                                                                                                            
                                                                                                                                                                                                                                 
  The description for the pippo repository in the lucadruda475 namespace has been updated to "a new description." However, the status could not be changed to active because the repository is currently inactive and has no     
  images. You may need to add images first or change the status manually on Docker Hub.
```

## Get Repository Info (official vs standard)
```
>>> give me details of nginx repository                                                                                                                                                                                          
                                                                                                                                                                                                                                 
    • Calling getRepositoryInfo...                                                                                                                                                                                               
                                                                                                                                                                                                                                 
  The nginx repository on Docker Hub is an official image maintained by the NGINX Docker Maintainers. Here are some key details:                                                                                                 
                                                                                                                                                                                                                                 
    • Namespace: library                                                                                                                                                                                                         
    • Repository name: nginx                                                                                                                                                                                                     
    • Description: Official build of Nginx, a high-performance web server, reverse proxy, and load balancer.                                                                                                                     
    • Status: Active                                                                                                                                                                                                             
    • Public repository (not private)                                                                                                                                                                                            
    • Stars: 20,877                                                                                                                                                                                                              
    • Pulls: Over 12 billion                                                                                                                                                                                                     
    • Last updated: July 2, 2025                                                                                                                                                                                                 
    • Registered since: June 5, 2014                                                                                                                                                                                             
    • Supported architectures include amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x                                                                                                         
    • Various tags available including mainline, stable, alpine, perl, otel, slim, and combinations thereof.                                                                                                                     
    • The repository provides Dockerfiles for different variants on GitHub: https://github.com/nginxinc/docker-nginx                                                                                                             
    • The image supports environment variable substitution in configuration templates.                                                                                                                                           
    • It can be run in read-only mode with appropriate volume mounts.                                                                                                                                                            
    • Debug mode is available with the nginx-debug binary.                                                                                                                                                                       
    • The image runs nginx as a non-root user by default for security.                                                                                                                                                           
    • License: BSD-like 2-clause license for nginx itself, with other software under their respective licenses.                                                                                                                  
                                                                                                                                                                                                                                 
  You can find the repository here: https://hub.docker.com/_/nginx                                                                                                                                                               
                                                                                                                                                                                                                                 
  If you want, I can provide more specific information such as usage examples, supported tags, or configuration tips.                                                                                                            
                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                 

>>> give me details of indexingtest repository                                                                                                                                                                                   
                                                                                                                                                                                                                                 
    • Calling getRepositoryInfo...                                                                                                                                                                                               
                                                                                                                                                                                                                                 
  I could not find a repository named "indexingtest" in the official library namespace on Docker Hub. Could you please confirm the repository name or provide the namespace if it is a user or organization repository?          
                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                 

>>> give me details of indexingtest repository in lucadruda475 namespace                                                                                                                                                         
    • Calling getRepositoryInfo...                                                                                                                                                                                               
                                                                                                                                                                                                                                 
  The "indexingtest" repository in the "lucadruda475" namespace has the following details:                                                                                                                                       
                                                                                                                                                                                                                                 
    • Description: a super new description                                                                                                                                                                                       
    • Repository type: image                                                                                                                                                                                                     
    • Status: active                                                                                                                                                                                                             
    • Private: No (public repository)                                                                                                                                                                                            
    • Automated build: No                                                                                                                                                                                                        
    • Star count: 0                                                                                                                                                                                                              
    • Pull count: 7                                                                                                                                                                                                              
    • Last updated: July 2, 2024                                                                                                                                                                                                 
    • Last modified: June 30, 2025                                                                                                                                                                                               
    • Date registered: July 2, 2024                                                                                                                                                                                              
    • Collaborator count: 0                                                                                                                                                                                                      
    • Affiliation: editor                                                                                                                                                                                                        
    • Hub user: lucadruda475                                                                                                                                                                                                     
    • Full description: a super new description                                                                                                                                                                                  
    • Permissions: read, write, admin (you have full access)                                                                                                                                                                     
    • Media types: application/vnd.docker.container.image.v1+json                                                                                                                                                                
    • Content types: image                                                                                                                                                                                                       
    • Categories: Monitoring & observability                                                                                                                                                                                     
    • Storage size: approximately 4.3 KB                                                                                                                                                                                         
                                                                                                                                                                                                                                 
  If you need more specific information or help with this repository, just let me know!
```

## Create Repository (LLM asks for the name)
```
>>> create a repository in my namespace                                                                                                                                                                                          
                                                                                                                                                                                                                                 
    • Calling getPersonalNamespace...                                                                                                                                                                                            
                                                                                                                                                                                                                                 
  Please provide the name and any description or details you'd like for the new repository in your namespace lucadruda475. 
```


## Tool Details
<!-- If modifying an existing tool, provide details -->
- Tool: getRepositoryInfo, updateRepositoryInfo
- Changes to: inputschema, logic

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [ ] I have updated the server README accordingly
- [ ] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->