### PR TITLE
Ensure Dockerfile has Linux-only npm packages in lock file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,10 @@ COPY package.json .
 COPY package-lock.json .
 COPY tsconfig.json .
 
-RUN npm ci
+# Refresh the lock file to be sure we include Linux-only packages that might not
+# be in the existing package-lock.json.
+RUN npm install --package-lock-only \
+    && npm ci
 
 COPY src/ ./src/
 


### PR DESCRIPTION


<!-- Provide a brief description of your changes -->

## Description

This PR updates the `Dockerfile` to regenerate the `package-lock.json` file during builds to ensure that Linux-only packages are included.  `docker build .` currently fails otherwise.

## Tool Details
n/a

## Motivation and Context
The package-lock.json file committed to the repository may lack Linux-only packages that wouldn't be installed by `npm install` on (say) macOS. This currently blocks `docker build .` from succeeding. The only robust solution to this is to allow lock file updatings during the Docker build.

## How Has This Been Tested?
Tested manually.

## Breaking Changes
n/a

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
@lucadruda I think this should have been caught by https://github.com/docker/hub-mcp/actions/workflows/release.yml, but it looks like that workflow was disabled.