### PR TITLE
Fix accounts/repos bugs and finalize tool metadata

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@ src/scout/genql
 .gitignore
 .github
 .vscode
+.claude
 package-lock.json
 package.json
 tsconfig.json

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -139,7 +139,7 @@ export class Accounts extends Asset {
             url,
             { method: 'GET' },
             `Here are the namespaces (Note: this list does not include the personal namespace): :response`,
-            `Error getting repositories for ${namespace}`
+            `Error getting namespaces`
         );
     }
 
@@ -160,11 +160,11 @@ export class Accounts extends Asset {
             };
         } catch (error) {
             return {
+                isError: true,
                 content: [
                     {
                         type: 'text',
                         text: `Error getting personal namespace: ${error}. Please provide the name of the personal namespace.`,
-                        isError: true,
                     },
                 ],
             };

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -20,6 +20,7 @@ import { z } from 'zod';
 import { createPaginatedResponseSchema } from './types';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
+import { logger } from './logger';
 
 //#region  Types
 const namespace = z.object({
@@ -45,6 +46,15 @@ const namespace = z.object({
 
 const namespacePaginatedResponseSchema = createPaginatedResponseSchema(namespace);
 export type NamespacePaginatedResponse = z.infer<typeof namespacePaginatedResponseSchema>;
+
+const allNamespacesResponseSchema = z.object({
+    namespaces: z
+        .array(z.string())
+        .optional()
+        .nullable()
+        .describe('All namespace names the user is a member of, including personal namespace'),
+    error: z.string().optional().nullable(),
+});
 //#endregion
 
 export class Accounts extends Asset {
@@ -100,22 +110,15 @@ export class Accounts extends Asset {
             this.server.registerTool(
                 'listAllNamespacesMemberOf',
                 {
-                    description: 'List all namespaces the user is a member of',
+                    description:
+                        'List all namespaces the user is a member of, including the personal namespace and all org namespaces.',
+                    outputSchema: allNamespacesResponseSchema.shape,
                     annotations: {
                         title: 'List All Namespaces user is a member of',
                     },
                     title: 'List all organisations (namespaces) the user is a member of including personal namespace',
                 },
-                () => {
-                    return {
-                        content: [
-                            {
-                                type: 'text',
-                                text: "To get all namespaces the user is a member of, call the 'listNamespaces' tool and the 'getPersonalNamespace' tool to get the personal namespace name.",
-                            },
-                        ],
-                    };
-                }
+                this.listAllNamespacesMemberOf.bind(this)
             )
         );
     }
@@ -143,18 +146,17 @@ export class Accounts extends Asset {
         );
     }
 
+    private async getUsername(): Promise<string> {
+        const token = await this.authenticate();
+        const jwt = jwtDecode<JwtPayload & { 'https://hub.docker.com': { username: string } }>(
+            token
+        );
+        return jwt['https://hub.docker.com'].username;
+    }
+
     private async getPersonalNamespace(): Promise<CallToolResult> {
         try {
-            const token = await this.authenticate();
-            const jwt = jwtDecode<
-                JwtPayload & {
-                    'https://hub.docker.com': {
-                        username: string;
-                    };
-                }
-            >(token);
-            const dockerData = jwt['https://hub.docker.com'];
-            const username = dockerData.username;
+            const username = await this.getUsername();
             return {
                 content: [{ type: 'text', text: `The personal namespace is ${username}` }],
             };
@@ -169,5 +171,55 @@ export class Accounts extends Asset {
                 ],
             };
         }
+    }
+
+    private async listAllNamespacesMemberOf(): Promise<CallToolResult> {
+        const namespaces: string[] = [];
+
+        // Get personal namespace from JWT
+        try {
+            const username = await this.getUsername();
+            namespaces.push(username);
+        } catch (error) {
+            logger.warn(`Could not get personal namespace: ${error}`);
+        }
+
+        // Paginate through all org namespaces
+        let page = 1;
+        const pageSize = 100;
+        try {
+            while (true) {
+                const url = `${this.config.host}/user/orgs?page=${page}&page_size=${pageSize}`;
+                const response = await this.authFetch<NamespacePaginatedResponse>(url, {
+                    method: 'GET',
+                });
+                const data = response.content;
+                if (data?.results) {
+                    namespaces.push(...data.results.map((ns) => ns.orgname));
+                }
+                if (!data?.next) break;
+                page++;
+            }
+        } catch (error) {
+            if (namespaces.length === 0) {
+                return {
+                    isError: true,
+                    content: [{ type: 'text', text: `Error getting namespaces: ${error}` }],
+                    structuredContent: { error: (error as Error).message },
+                };
+            }
+            // Return what we have so far
+            logger.warn(`Could not fetch all org namespaces: ${error}`);
+        }
+
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `Here are all namespaces the user is a member of: ${namespaces.join(', ')}`,
+                },
+            ],
+            structuredContent: { namespaces },
+        };
     }
 }

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -95,7 +95,6 @@ const Repository = z.object({
         .number()
         .nullable()
         .optional()
-        .nullable()
         .describe('The storage size of the repository'),
     user: z.string().optional().nullable().describe('The user of the repository'),
     hub_user: z.string().optional().nullable().describe('The repository username on hub'),
@@ -544,16 +543,17 @@ export class Repos extends Asset {
             page_size = 10;
         }
         let url = `${this.config.host}/namespaces/${namespace}/repositories/${repository}/tags`;
-        const params: Record<string, string> = {};
+        const params: Record<string, string> = {
+            page: page.toString(),
+            page_size: page_size.toString(),
+        };
         if (architecture) {
             params.architecture = architecture;
         }
         if (os) {
             params.os = os;
         }
-        if (Object.keys(params).length > 0) {
-            url += `?${new URLSearchParams(params).toString()}`;
-        }
+        url += `?${new URLSearchParams(params).toString()}`;
 
         return this.callAPI<RepositoryTagPaginatedResponse>(
             url,
@@ -655,9 +655,10 @@ export class Repos extends Asset {
             const currentStatus = (
                 currentRepository.structuredContent as z.infer<typeof Repository>
             ).status;
-            if (currentStatus !== status) {
+            const currentStatusStr = currentStatus === 1 ? 'active' : 'inactive';
+            if (currentStatusStr !== status) {
                 logger.info(
-                    `Repository ${repository} in ${namespace} is currently in status ${currentStatus}. Updating to ${status}.`
+                    `Repository ${repository} in ${namespace} is currently in status ${currentStatusStr}. Updating to ${status}.`
                 );
                 if (status === 'active') {
                     return {
@@ -673,10 +674,10 @@ export class Repos extends Asset {
                         },
                     };
                 }
-                body.status = status === 'active' ? 1 : 0;
+                body.status = 0;
                 extraContent.push({
                     type: 'text',
-                    text: `Requested a status change from ${currentStatus} to ${status}. This is potentially a dangerous operation and should be done with caution. If you are not sure, please go on Docker Hub and revert the status manually.\nhttps://hub.docker.com/r/${namespace}/${repository}`,
+                    text: `Requested a status change from ${currentStatusStr} to ${status}. This is potentially a dangerous operation and should be done with caution. If you are not sure, please go on Docker Hub and revert the status manually.\nhttps://hub.docker.com/r/${namespace}/${repository}`,
                 });
             }
         }

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -239,6 +239,10 @@ export class Repos extends Asset {
                     description: 'List paginated repositories by namespace',
                     inputSchema: {
                         namespace: z.string().describe('The namespace to list repositories from'),
+                        name: z
+                            .string()
+                            .optional()
+                            .describe('Filter repositories by name (partial match supported)'),
                         page: z
                             .number()
                             .optional()
@@ -473,10 +477,56 @@ export class Repos extends Asset {
                 this.checkRepositoryTag.bind(this)
             )
         );
+
+        // Delete Repository
+        this.tools.set(
+            'deleteRepository',
+            this.server.registerTool(
+                'deleteRepository',
+                {
+                    description:
+                        'Delete a repository in the given namespace. This is a destructive and irreversible operation. You MUST ask the user to explicitly confirm before calling this tool.',
+                    inputSchema: z.object({
+                        namespace: z.string().describe('The namespace of the repository (required)'),
+                        repository: z.string().describe('The repository name (required)'),
+                    }).shape,
+                    annotations: {
+                        title: 'Delete Repository',
+                        destructiveHint: true,
+                    },
+                    title: 'Delete a repository',
+                },
+                this.deleteRepository.bind(this)
+            )
+        );
+
+        // Delete Repository Tag
+        this.tools.set(
+            'deleteRepositoryTag',
+            this.server.registerTool(
+                'deleteRepositoryTag',
+                {
+                    description:
+                        'Delete a tag from a repository. This is a destructive and irreversible operation. You MUST ask the user to explicitly confirm before calling this tool.',
+                    inputSchema: z.object({
+                        namespace: z.string().describe('The namespace of the repository (required)'),
+                        repository: z.string().describe('The repository name (required)'),
+                        tag: z.string().describe('The tag name to delete (required)'),
+                    }).shape,
+                    annotations: {
+                        title: 'Delete Repository Tag',
+                        destructiveHint: true,
+                    },
+                    title: 'Delete a tag from a repository',
+                },
+                this.deleteRepositoryTag.bind(this)
+            )
+        );
     }
 
     private async listRepositoriesByNamespace({
         namespace,
+        name,
         page,
         page_size,
         ordering,
@@ -484,6 +534,7 @@ export class Repos extends Asset {
         content_types,
     }: {
         namespace: string;
+        name?: string;
         page?: number;
         page_size?: number;
         ordering?: string;
@@ -500,6 +551,9 @@ export class Repos extends Asset {
             page_size = 10;
         }
         let url = `${this.config.host}/namespaces/${namespace}/repositories?page=${page}&page_size=${page_size}`;
+        if (name) {
+            url += `&name=${encodeURIComponent(name)}`;
+        }
         if (ordering) {
             url += `&ordering=${ordering}`;
         }
@@ -754,6 +808,46 @@ export class Repos extends Asset {
             { method: 'HEAD' },
             `Repository :${repository} in ${namespace} contains tag ${tag}.`,
             `Repository :${repository} in ${namespace} does not contain tag ${tag}.`
+        );
+    }
+
+    private async deleteRepository({
+        namespace,
+        repository,
+    }: {
+        namespace: string;
+        repository: string;
+    }): Promise<CallToolResult> {
+        if (!namespace || !repository) {
+            throw new Error('Namespace and repository name are required');
+        }
+        const url = `${this.config.host}/namespaces/${namespace}/repositories/${repository}`;
+        return this.callAPI(
+            url,
+            { method: 'DELETE' },
+            `Repository ${namespace}/${repository} has been deleted successfully.`,
+            `Error deleting repository ${namespace}/${repository}`
+        );
+    }
+
+    private async deleteRepositoryTag({
+        namespace,
+        repository,
+        tag,
+    }: {
+        namespace: string;
+        repository: string;
+        tag: string;
+    }): Promise<CallToolResult> {
+        if (!namespace || !repository || !tag) {
+            throw new Error('Namespace, repository name and tag are required');
+        }
+        const url = `${this.config.host}/namespaces/${namespace}/repositories/${repository}/tags/${tag}`;
+        return this.callAPI(
+            url,
+            { method: 'DELETE' },
+            `Tag ${tag} in ${namespace}/${repository} has been deleted successfully.`,
+            `Error deleting tag ${tag} in ${namespace}/${repository}`
         );
     }
 }

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -91,11 +91,7 @@ const Repository = z.object({
         .optional()
         .nullable()
         .describe('The categories of the repository'),
-    storage_size: z
-        .number()
-        .nullable()
-        .optional()
-        .describe('The storage size of the repository'),
+    storage_size: z.number().nullable().optional().describe('The storage size of the repository'),
     user: z.string().optional().nullable().describe('The user of the repository'),
     hub_user: z.string().optional().nullable().describe('The repository username on hub'),
     has_starred: z
@@ -487,7 +483,9 @@ export class Repos extends Asset {
                     description:
                         'Delete a repository in the given namespace. This is a destructive and irreversible operation. You MUST ask the user to explicitly confirm before calling this tool.',
                     inputSchema: z.object({
-                        namespace: z.string().describe('The namespace of the repository (required)'),
+                        namespace: z
+                            .string()
+                            .describe('The namespace of the repository (required)'),
                         repository: z.string().describe('The repository name (required)'),
                     }).shape,
                     annotations: {
@@ -509,7 +507,9 @@ export class Repos extends Asset {
                     description:
                         'Delete a tag from a repository. This is a destructive and irreversible operation. You MUST ask the user to explicitly confirm before calling this tool.',
                     inputSchema: z.object({
-                        namespace: z.string().describe('The namespace of the repository (required)'),
+                        namespace: z
+                            .string()
+                            .describe('The namespace of the repository (required)'),
                         repository: z.string().describe('The repository name (required)'),
                         tag: z.string().describe('The tag name to delete (required)'),
                     }).shape,

--- a/tools.json
+++ b/tools.json
@@ -10,6 +10,10 @@
                         "type": "string",
                         "description": "The namespace to list repositories from"
                     },
+                    "name": {
+                        "type": "string",
+                        "description": "Filter repositories by name (partial match supported)"
+                    },
                     "page": {
                         "type": "number",
                         "description": "The page number to list repositories from"
@@ -422,21 +426,7 @@
                                                     "description": "The categories of the repository"
                                                 },
                                                 "storage_size": {
-                                                    "anyOf": [
-                                                        {
-                                                            "anyOf": [
-                                                                {
-                                                                    "not": {}
-                                                                },
-                                                                {
-                                                                    "type": ["number", "null"]
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "type": "null"
-                                                        }
-                                                    ],
+                                                    "type": ["number", "null"],
                                                     "description": "The storage size of the repository"
                                                 },
                                                 "user": {
@@ -1004,21 +994,7 @@
                         "description": "The categories of the repository"
                     },
                     "storage_size": {
-                        "anyOf": [
-                            {
-                                "anyOf": [
-                                    {
-                                        "not": {}
-                                    },
-                                    {
-                                        "type": ["number", "null"]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
+                        "type": ["number", "null"],
                         "description": "The storage size of the repository"
                     },
                     "user": {
@@ -1536,21 +1512,7 @@
                         "description": "The categories of the repository"
                     },
                     "storage_size": {
-                        "anyOf": [
-                            {
-                                "anyOf": [
-                                    {
-                                        "not": {}
-                                    },
-                                    {
-                                        "type": ["number", "null"]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
+                        "type": ["number", "null"],
                         "description": "The storage size of the repository"
                     },
                     "user": {
@@ -2096,21 +2058,7 @@
                         "description": "The categories of the repository"
                     },
                     "storage_size": {
-                        "anyOf": [
-                            {
-                                "anyOf": [
-                                    {
-                                        "not": {}
-                                    },
-                                    {
-                                        "type": ["number", "null"]
-                                    }
-                                ]
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
+                        "type": ["number", "null"],
                         "description": "The storage size of the repository"
                     },
                     "user": {
@@ -3319,6 +3267,58 @@
             }
         },
         {
+            "name": "deleteRepository",
+            "description": "Delete a repository",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "The namespace of the repository (required)"
+                    },
+                    "repository": {
+                        "type": "string",
+                        "description": "The repository name (required)"
+                    }
+                },
+                "required": ["namespace", "repository"],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+            },
+            "annotations": {
+                "title": "Delete Repository",
+                "destructiveHint": true
+            }
+        },
+        {
+            "name": "deleteRepositoryTag",
+            "description": "Delete a tag from a repository",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "description": "The namespace of the repository (required)"
+                    },
+                    "repository": {
+                        "type": "string",
+                        "description": "The repository name (required)"
+                    },
+                    "tag": {
+                        "type": "string",
+                        "description": "The tag name to delete (required)"
+                    }
+                },
+                "required": ["namespace", "repository", "tag"],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+            },
+            "annotations": {
+                "title": "Delete Repository Tag",
+                "destructiveHint": true
+            }
+        },
+        {
             "name": "listNamespaces",
             "description": "List organisations (namespaces) the user has access to",
             "inputSchema": {
@@ -3523,6 +3523,51 @@
             },
             "annotations": {
                 "title": "List All Namespaces user is a member of"
+            },
+            "outputSchema": {
+                "type": "object",
+                "properties": {
+                    "namespaces": {
+                        "anyOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "not": {}
+                                    },
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "All namespace names the user is a member of, including personal namespace"
+                    },
+                    "error": {
+                        "anyOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "not": {}
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
             }
         },
         {

--- a/tools.txt
+++ b/tools.txt
@@ -6,6 +6,8 @@
 - name: listRepositoryTags
 - name: getRepositoryTag
 - name: checkRepositoryTag
+- name: deleteRepository
+- name: deleteRepositoryTag
 - name: listNamespaces
 - name: getPersonalNamespace
 - name: listAllNamespacesMemberOf


### PR DESCRIPTION
## Summary
- implement real `listAllNamespacesMemberOf` behavior and output schema support
- add repository `name` filter plus destructive delete tools (`deleteRepository`, `deleteRepositoryTag`)
- regenerate `tools.json` / `tools.txt` to reflect new tools and schemas
- fix formatting drift in `src/repos.ts`
- ignore local `.claude` config in `.prettierignore` so local settings do not fail format checks

## Validation
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run list-tools:check`

## Notes
- branch is hosted from a proper fork (`abouchard11/hub-mcp-fork`) because `abouchard11/hub-mcp` is not a fork relationship of `docker/hub-mcp`
