### PR TITLE
Mark read-only Docker Hub tools with readOnlyHint

### DIFF
--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -56,6 +56,7 @@ export class Accounts extends Asset {
     }
 
     RegisterTools(): void {
+        // Fork note: these namespace lookups are read-only and should stay marked as such.
         this.tools.set(
             'listNamespaces',
             this.server.registerTool(
@@ -75,6 +76,7 @@ export class Accounts extends Asset {
                     outputSchema: namespacePaginatedResponseSchema.shape,
                     annotations: {
                         title: 'List Namespaces',
+                        readOnlyHint: true,
                     },
                     title: 'List organisations (namespaces) the user has access to',
                 },
@@ -89,6 +91,7 @@ export class Accounts extends Asset {
                     description: 'Get the personal namespace name',
                     annotations: {
                         title: 'Get Personal Namespace',
+                        readOnlyHint: true,
                     },
                     title: 'Get user personal namespace',
                 },
@@ -103,6 +106,7 @@ export class Accounts extends Asset {
                     description: 'List all namespaces the user is a member of',
                     annotations: {
                         title: 'List All Namespaces user is a member of',
+                        readOnlyHint: true,
                     },
                     title: 'List all organisations (namespaces) the user is a member of including personal namespace',
                 },

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -231,6 +231,7 @@ export class Repos extends Asset {
     }
 
     RegisterTools(): void {
+        // Fork note: non-mutating repository and tag operations must keep readOnlyHint=true.
         // List Repositories by Namespace
         this.tools.set(
             'listRepositoriesByNamespace',
@@ -279,6 +280,7 @@ export class Repos extends Asset {
                     outputSchema: repositoryPaginatedResponseSchema.shape,
                     annotations: {
                         title: 'List Repositories by Namespace',
+                        readOnlyHint: true,
                     },
                     title: 'List Repositories by Organisation (namespace)',
                 },
@@ -321,6 +323,7 @@ export class Repos extends Asset {
                     outputSchema: Repository.shape,
                     annotations: {
                         title: 'Get Repository Info',
+                        readOnlyHint: true,
                     },
                     title: 'Get Repository Details',
                 },
@@ -382,6 +385,7 @@ export class Repos extends Asset {
                     inputSchema: z.object({ namespace: z.string(), repository: z.string() }).shape,
                     annotations: {
                         title: 'Check Repository Exists',
+                        readOnlyHint: true,
                     },
                     title: 'Check Repository Exists',
                 },
@@ -425,6 +429,7 @@ export class Repos extends Asset {
                     outputSchema: repositoryTagPaginatedResponseSchema.shape,
                     annotations: {
                         title: 'List Repository Tags',
+                        readOnlyHint: true,
                     },
                     title: 'List tags by repository',
                 },
@@ -448,6 +453,7 @@ export class Repos extends Asset {
                     outputSchema: RepositoryTag.shape,
                     annotations: {
                         title: 'Get Repository Tag',
+                        readOnlyHint: true,
                     },
                     title: 'Get Repository Tag Details',
                 },
@@ -468,6 +474,7 @@ export class Repos extends Asset {
                     }).shape,
                     annotations: {
                         title: 'Check Repository Tag',
+                        readOnlyHint: true,
                     },
                     title: 'Check Repository Tag Exists',
                 },

--- a/src/scout.ts
+++ b/src/scout.ts
@@ -56,6 +56,7 @@ export class ScoutAPI extends Asset {
         });
     }
     RegisterTools(): void {
+        // Fork note: DHI discovery is a read-only query and should stay marked as such.
         this.tools.set(
             'dockerHardenedImages',
             this.server.registerTool(
@@ -72,6 +73,7 @@ export class ScoutAPI extends Asset {
                     }).shape,
                     annotations: {
                         title: 'List available Docker Hardened Images',
+                        readOnlyHint: true,
                     },
                     title: 'List available Docker Hardened Images in user organisations',
                 },

--- a/src/search.ts
+++ b/src/search.ts
@@ -89,6 +89,7 @@ export class Search extends Asset {
     }
 
     RegisterTools(): void {
+        // Fork note: Docker Hub search is non-mutating and should stay marked as read-only.
         this.tools.set(
             'search',
             this.server.registerTool(
@@ -149,6 +150,7 @@ export class Search extends Asset {
                     outputSchema: searchResults.shape,
                     annotations: {
                         title: 'Search Repositories',
+                        readOnlyHint: true,
                     },
                     title: 'Search Repositories',
                 },

--- a/tools.json
+++ b/tools.json
@@ -46,7 +46,8 @@
                 "$schema": "http://json-schema.org/draft-07/schema#"
             },
             "annotations": {
-                "title": "List Repositories by Namespace"
+                "title": "List Repositories by Namespace",
+                "readOnlyHint": true
             },
             "outputSchema": {
                 "type": "object",
@@ -1204,7 +1205,8 @@
                 "$schema": "http://json-schema.org/draft-07/schema#"
             },
             "annotations": {
-                "title": "Get Repository Info"
+                "title": "Get Repository Info",
+                "readOnlyHint": true
             },
             "outputSchema": {
                 "type": "object",
@@ -2294,7 +2296,8 @@
                 "$schema": "http://json-schema.org/draft-07/schema#"
             },
             "annotations": {
-                "title": "Check Repository Exists"
+                "title": "Check Repository Exists",
+                "readOnlyHint": true
             }
         },
         {
@@ -2333,7 +2336,8 @@
                 "$schema": "http://json-schema.org/draft-07/schema#"
             },
             "annotations": {
-                "title": "List Repository Tags"
+                "title": "List Repository Tags",
+                "readOnlyHint": true
             },
             "outputSchema": {
                 "type": "object",
@@ -2866,7 +2870,8 @@
                 "$schema": "http://json-schema.org/draft-07/schema#"
             },
             "annotations": {
-                "title": "Get Repository Tag"
+                "title": "Get Repository Tag",
+                "readOnlyHint": true
             },
             "outputSchema": {
                 "type": "object",
@@ -3315,7 +3320,8 @@
                 "$schema": "http://json-schema.org/draft-07/schema#"
             },
             "annotations": {
-                "title": "Check Repository Tag"
+                "title": "Check Repository Tag",
+                "readOnlyHint": true
             }
         },
         {
@@ -3337,7 +3343,8 @@
                 "$schema": "http://json-schema.org/draft-07/schema#"
             },
             "annotations": {
-                "title": "List Namespaces"
+                "title": "List Namespaces",
+                "readOnlyHint": true
             },
             "outputSchema": {
                 "type": "object",
@@ -3512,7 +3519,8 @@
                 "type": "object"
             },
             "annotations": {
-                "title": "Get Personal Namespace"
+                "title": "Get Personal Namespace",
+                "readOnlyHint": true
             }
         },
         {
@@ -3522,7 +3530,8 @@
                 "type": "object"
             },
             "annotations": {
-                "title": "List All Namespaces user is a member of"
+                "title": "List All Namespaces user is a member of",
+                "readOnlyHint": true
             }
         },
         {
@@ -3631,7 +3640,8 @@
                 "$schema": "http://json-schema.org/draft-07/schema#"
             },
             "annotations": {
-                "title": "Search Repositories"
+                "title": "Search Repositories",
+                "readOnlyHint": true
             },
             "outputSchema": {
                 "type": "object",
@@ -3865,7 +3875,8 @@
                 "$schema": "http://json-schema.org/draft-07/schema#"
             },
             "annotations": {
-                "title": "List available Docker Hardened Images"
+                "title": "List available Docker Hardened Images",
+                "readOnlyHint": true
             }
         }
     ]


### PR DESCRIPTION
## Summary
- add `readOnlyHint: true` to read-only Docker Hub MCP tools
- update generated tool metadata in `tools.json`

## Why
Several Docker Hub tools are read-only, but they are currently published without `readOnlyHint`. MCP clients can then classify them as potentially mutating and prompt more aggressively than needed.

This patch marks the non-mutating account, repository, tag, hardened-image, and search tools as read-only.

## Scope
This PR intentionally excludes fork-specific repo maintenance changes such as CI hardening, CODEOWNERS, release workflow changes, and Docker Hub publishing setup. It keeps the upstream proposal limited to the MCP metadata fix itself.

## Validation
- `npm run lint` passed locally on Windows
- The modified files were reviewed directly against the current upstream sources
- Full upstream validation is expected to come from GitHub Actions on this PR

Note: local `npm run build` and `npm run list-tools:check` hit a Windows-specific Node heap exhaustion in this environment, so I am not claiming those as local passes.
