### PR TITLE
Fix Docker Hub PAT auth flow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.js text eol=lf
+*.json text eol=lf
+*.mjs text eol=lf
+*.ts text eol=lf
+*.txt text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf

--- a/src/asset.ts
+++ b/src/asset.ts
@@ -202,13 +202,13 @@ export class Asset implements Asset {
             throw new Error('PAT auth: Username is empty');
         }
         console.error(`Authenticating PAT for ${username}`);
-        const url = `https://hub.docker.com/v2/users/login`;
+        const url = `https://hub.docker.com/v2/auth/token`;
         const response = await fetch(url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-                username: username,
-                password: this.config.auth?.token,
+                identifier: username,
+                secret: this.config.auth?.token?.trim(),
             }),
         });
         if (!response.ok) {
@@ -217,9 +217,11 @@ export class Asset implements Asset {
             );
         }
         const data = (await response.json()) as {
-            token: string;
-            refresh_token: string;
+            access_token: string;
         };
-        return data.token;
+        if (!data.access_token) {
+            throw new Error(`Failed to authenticate PAT for ${username}: missing access token`);
+        }
+        return data.access_token;
     }
 }

--- a/src/scripts/toolsList.ts
+++ b/src/scripts/toolsList.ts
@@ -102,7 +102,9 @@ function loadCurrentToolsList(): { tools: Tool[] } {
 
 function loadCurrentToolsNames(): string[] {
     const toolsList = fs.readFileSync(path.join(__dirname, '../..', 'tools.txt'), 'utf8');
-    return toolsList.split('\n').map((line) => line.split('- name: ')[1].replace(/^"|"$/g, ''));
+    return toolsList
+        .split('\n')
+        .map((line) => line.trimEnd().split('- name: ')[1].replace(/^"|"$/g, ''));
 }
 
 function saveToolsList(toolsList: { tools: Tool[] }) {


### PR DESCRIPTION
## Summary
- exchange Docker Hub PATs through the documented `/v2/auth/token` endpoint
- trim PAT input before exchange so secrets stored with a trailing newline still authenticate
- make the tools-list checker tolerate CRLF in `tools.txt`
- add Git attributes for LF-normalized source/check files to match the existing Prettier config

## Validation
- npm run format:check
- npm run build
- npm run list-tools:check
- MCP smoke test: `getPersonalNamespace` returns the authenticated namespace with a PAT